### PR TITLE
feat: add option to set maximum stat caps

### DIFF
--- a/worlds/mina_the_hollower/__init__.py
+++ b/worlds/mina_the_hollower/__init__.py
@@ -148,6 +148,7 @@ class MinaTheHollowerWorld(MinaTheHollowerBase):
             "goal": self.options.goal.value,
             "ossex_start": self.options.ossex_start.value,
             "kear_rando": self.options.kear_rando.value,
+            "max_stat_level": self.options.max_stat_level.value,
             # "entrance_rando" : self.options.entrance_rando.value,
             "death_link": self.options.death_link.value,
             # The client disables each ability while its "*_rando" key is nonzero.

--- a/worlds/mina_the_hollower/archipelago.json
+++ b/worlds/mina_the_hollower/archipelago.json
@@ -1,7 +1,7 @@
 {
     "game": "Mina The Hollower",
     "world_version": "0.4.6",
-    "mod_version": "0.6.0",
+    "mod_version": "0.6.3",
     "minimum_ap_version": "0.6.7",
     "authors": [
         "FyreDay, Axertin"

--- a/worlds/mina_the_hollower/items.py
+++ b/worlds/mina_the_hollower/items.py
@@ -8,7 +8,7 @@ from .data.items import Kear, SingleKears, AreaKears, base_items, Abilities, Bon
     trinket_powers, upgrade_powers, valid_power_types
 from .data.rules.ability_rules import CanJumpTiles
 from .data.rules.state_rules import sidearm_rules
-from .options import BoneUpCap, KearRandomization
+from .options import BoneUpCap, KearRandomization, MaximumStatLevel
 
 from typing import TYPE_CHECKING
 
@@ -55,10 +55,10 @@ def create_items(world: "MinaTheHollowerWorld"):
     # dont want to start
     if world.options.bone_up_cap == BoneUpCap.option_perUpgrade:
         for item_type in BoneUps:
-            for _ in range(9):
+            for _ in range(world.options.max_stat_level.value - 1):
                 all_items.append(ItemData(item_type, 1))
     else:
-        for _ in range(9):
+        for _ in range(world.options.max_stat_level.value - 1):
             all_items.append(ItemData(GenericBoneUp.ALL_BONE_UP_CAP, 1))
 
     starting_items: list[Item] = [] if not is_ut else world.starting_items

--- a/worlds/mina_the_hollower/options.py
+++ b/worlds/mina_the_hollower/options.py
@@ -30,6 +30,15 @@ class NumberOfGenerators(Range):
     range_end = 6
     default = 6
 
+class MaximumStatLevel(Range):
+    """
+    The maximum cap of each stat. Vanilla non-NG+ is 10, maximum at the end of the NG+es is 99
+    """
+    display_name = "Maximum Stat Caps"
+    range_start = 10
+    range_end = 99
+    default = 20
+
 class OssexStart(DefaultOnToggle):
     """
     Start In Ossex
@@ -125,6 +134,7 @@ mina_the_hollower_option_groups= [
     OptionGroup("AP Options", [
         Goal,
         BoneUpCap,
+        MaximumStatLevel,
         OssexStart,
         KearRandomization,
         ExcludedAreas,
@@ -142,6 +152,7 @@ class MinaTheHollowerOptions(PerGameCommonOptions):
     kear_rando: KearRandomization
     # excluded_areas : ExcludedAreas
     bone_up_cap: BoneUpCap
+    max_stat_level: MaximumStatLevel
     random_starting_items: RandomizeStartingItems
     # entrance_rando: RandomizeEntrances
     ability_rando: AbilityRando


### PR DESCRIPTION
Adds the appropriate number of bone up cap items to the pool.